### PR TITLE
posts: update domain

### DIFF
--- a/src/data/posts.ts
+++ b/src/data/posts.ts
@@ -3,31 +3,31 @@ const allPosts = [
 	{
 		date: "2024-04-28",
 		id: 1,
-		link: "https://blog.nihilism.network/servers/monero2024/index.html",
+		link: "https://blog.nowhere.moe/servers/monero2024/index.html",
 		title: "How to acquire and use Monero",
 	},
 	{
 		date: "2024-05-14",
 		id: 2,
-		link: "https://blog.nihilism.network/servers/haveno-client-f2f/index.html",
+		link: "https://blog.nowhere.moe/servers/haveno-client-f2f/index.html",
 		title: "Haveno Decentralised Exchange direct Fiat -> XMR transaction",
 	},
 	{
 		date: "2024-05-19",
 		id: 3,
-		link: "https://blog.nihilism.network/servers/haveno-arbitrator/index.html",
+		link: "https://blog.nowhere.moe/servers/haveno-arbitrator/index.html",
 		title: "Haveno DEX Dispute resolution (Fiat -> XMR)",
 	},
 	{
 		date: " 2024-05-20",
 		id: 4,
-		link: "https://blog.nihilism.network/servers/haveno-sepa/index.html",
+		link: "https://blog.nowhere.moe/servers/haveno-sepa/index.html",
 		title: "Haveno DEX Bank Transfer (ex: SEPA) -> XMR transaction",
 	},
 	{
 		date: "2024-05-19",
 		id: 5,
-		link: "https://blog.nihilism.network/servers/haveno-cashbymail/index.html",
+		link: "https://blog.nowhere.moe/servers/haveno-cashbymail/index.html",
 		title: "Haveno DEX Cash By Mail -> XMR transaction",
 	},
 ];


### PR DESCRIPTION
Nihilism network services and content have migrated to Nowhere moe's domain. PR swaps nihilism.network for nowhere.moe where needed.