### PR TITLE
index: fix TOR typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
                 <div class="w-layout-hflex h1-and-cta">
                   <div class="h1-wrapper">
                     <div class="tagblock"><img src="images/Frame-1000002895.svg" loading="lazy" alt="" class="icon-1x1-24">
-                      <div>Powered by TOR</div>
+                      <div>Powered by Tor</div>
                     </div>
                     <h1 class="text-color-white">Buy &amp; Sell Monero</h1>
                     <div class="text-color-white-60">Exchange, Secure, Direct, P2P</div>
@@ -208,7 +208,7 @@
                     <div id="w-node-_4b1c4cb3-6002-a5dc-214a-84f54548773e-d144478d" class="bento-card-big">
                       <div class="h3-wrapper">
                         <div class="text-color-white">
-                          <h3>Powered by Monero &amp; TOR</h3>
+                          <h3>Powered by Monero &amp; Tor</h3>
                         </div>
                         <div>Secure Connection. Private Blockchain.</div>
                       </div><img src="images/Bento-grid-3.png" loading="lazy" sizes="(max-width: 479px) 100vw, (max-width: 767px) 96vw, 46vw" srcset="images/Bento-grid-3-p-500.png 500w, images/Bento-grid-3-p-800.png 800w, images/Bento-grid-3-p-1080.png 1080w, images/Bento-grid-3.png 1760w" alt="" class="bento-big-image">


### PR DESCRIPTION
> Note: even though it originally came from an acronym, Tor is not spelled "TOR". Only the first letter is capitalized. In fact, we can usually spot people who haven't read any of our website (and have instead learned everything they know about Tor from news articles) by the fact that they spell it wrong.

See: https://support.torproject.org/about/why-is-it-called-tor/#:~:text=Note:%20even%20though%20it%20originally,the%20first%20letter%20is%20capitalized.

