### PR TITLE
Add architecture-specific macOS download buttons

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -2403,6 +2403,12 @@ figcaption {
   display: grid;
 }
 
+.macos-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+}
+
 .download-grid-and-cta {
   grid-column-gap: 1rem;
   grid-row-gap: 1rem;

--- a/index.html
+++ b/index.html
@@ -535,9 +535,14 @@
                           <div class="subtitle-18">RetoSwap for Mac</div>
                         </div>
                         <div class="download-card-bottom">
-                          <a href="https://github.com/retoaccess1/haveno-reto/releases/download/1.2.2-reto/haveno-v1.2.2-macos-x86_64-installer.dmg" class="button-second w-inline-block">
-                            <div>Download</div>
-                          </a>
+                          <div class="macos-buttons">
+                            <a href="https://github.com/retoaccess1/haveno-reto/releases/download/1.2.2-reto/haveno-v1.2.2-macos-x86_64-installer.dmg" class="button-second w-inline-block">
+                              <div>Intel</div>
+                            </a>
+                            <a href="https://github.com/retoaccess1/haveno-reto/releases/download/1.2.2-reto/haveno-v1.2.2-macos-aarch64-installer.dmg" class="button-second w-inline-block">
+                              <div>Apple Silicon</div>
+                            </a>
+                          </div>
                         </div>
                       </div>
                       <div class="stroke-rectangle is-white"></div>


### PR DESCRIPTION
Separate the macOS download button into two distinct options for
Intel and Apple Silicon architectures. Users can now select the
appropriate installer (x86_64 or aarch64) for their Mac hardware.

The download section now displays:
* Intel Mac download option (x86_64 DMG)
* Apple Silicon Mac download option (aarch64 DMG)

---

<img width="931" height="374" alt="image" src="https://github.com/user-attachments/assets/29eb47eb-6576-4f76-a3e3-9e806dea98cf" />
